### PR TITLE
Added remote cfGMM branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
   fossil,
   ggpubr,
   rmdformats
+Remotes: github::JiangmeiRubyXiong/cfGMM
 RoxygenNote: 7.2.3
 Suggests: 
     knitr,


### PR DESCRIPTION
My installation was failing with the following error:

```
ERROR: dependency ‘cfGMM’ is not available for package ‘GammaGateR’
* removing ‘/Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library/GammaGateR’
Warning messages:
1: package ‘cfGMM’ is not available for this version of R

A version of this package for your version of R might be available elsewhere,
see the ideas at
https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Installing-packages 
2: In i.p(...) : installation of package ‘lme4’ had non-zero exit status
3: In i.p(...) :
  installation of package ‘/var/folders/jz/pkw0zld53pz3dxvzc5fs4hy00000gn/T//RtmpGab1yk/file33765a79198f/GammaGateR_0.1.0.tar.gz’ had non-zero exit status
```

I think this is because the repository for `cfGMM` isn't in the `DESCRIPTION` file- I added it, and it seems to be working.